### PR TITLE
CompatHelper: bump compat for "HCIToolbox" to "0.2"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Distributions = "0.22,0.23"
-HCIToolbox = "0.1"
+HCIToolbox = "0.1, 0.2"
 ImageFiltering = "0.6"
 ImageTransformations = "0.8"
 KernelDensity = "0.5"


### PR DESCRIPTION
This pull request changes the compat entry for the `HCIToolbox` package from `0.1` to `0.1, 0.2`.

This keeps the compat entries for earlier versions.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request.